### PR TITLE
Fix external link symbol

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
 // SPDX-License-Identifier: CC0-1.0
 
-import {rehypeHeadingIds} from '@astrojs/markdown-remark';
+import { rehypeHeadingIds } from '@astrojs/markdown-remark';
 import starlight from '@astrojs/starlight';
 import icon from 'astro-icon';
-import {defineConfig} from 'astro/config';
+import { defineConfig } from 'astro/config';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 
 // https://astro.build/config
@@ -19,8 +19,7 @@ export default defineConfig({
         alt: 'Kando Logo',
       },
       editLink: {
-        baseUrl:
-            'https://github.com/kando-menu/kando-menu.github.io/edit/main/',
+        baseUrl: 'https://github.com/kando-menu/kando-menu.github.io/edit/main/',
       },
       social: {
         github: 'https://github.com/kando-menu/kando',
@@ -75,31 +74,31 @@ export default defineConfig({
           label: 'Reference',
           collapsed: true,
           items: [
-            'commandline-interface', 'config-files', 'valid-keynames',
-            'release-management'
+            'commandline-interface',
+            'config-files',
+            'valid-keynames',
+            'release-management',
           ],
         },
         {
-          label: 'Discord 🗗',
+          label: 'Discord ↗',
           link: 'https://discord.gg/hZwbVSDkhy',
-          attrs: {target: '_blank'},
+          attrs: { target: '_blank' },
         },
         {
-          label: 'Issue Tracker 🗗',
+          label: 'Issue Tracker ↗',
           link: 'https://github.com/kando-menu/kando/issues',
-          attrs: {target: '_blank'},
+          attrs: { target: '_blank' },
         },
         {
-          label: 'Changelog 🗗',
-          link:
-              'https://github.com/kando-menu/kando/blob/main/docs/changelog.md',
-          attrs: {target: '_blank'},
+          label: 'Changelog ↗',
+          link: 'https://github.com/kando-menu/kando/blob/main/docs/changelog.md',
+          attrs: { target: '_blank' },
         },
         {
-          label: 'Code of Conduct 🗗',
-          link:
-              'https://github.com/kando-menu/kando/blob/main/docs/code-of-conduct.md',
-          attrs: {target: '_blank'},
+          label: 'Code of Conduct ↗',
+          link: 'https://github.com/kando-menu/kando/blob/main/docs/code-of-conduct.md',
+          attrs: { target: '_blank' },
         },
       ],
       lastUpdated: true,

--- a/src/content/docs/donating.mdx
+++ b/src/content/docs/donating.mdx
@@ -24,16 +24,16 @@ If you want to support me, you can do so in the following ways:
 
 <CardGrid stagger>
   <CustomCard title="Via Ko-fi!" icon="simple-icons:kofi">
-    Send a single cup of coffee or a monthly supply <a href="https://ko-fi.com/schneegans" target="_blank">here 🗗</a>!
+    Send a single cup of coffee or a monthly supply <a href="https://ko-fi.com/schneegans" target="_blank">here ↗</a>!
   </CustomCard>
   <CustomCard title="Via GitHub!" icon="simple-icons:github">
-    You can also donate via the <a href="https://github.com/sponsors/Schneegans" target="_blank">GitHub Sponsors Program 🗗</a>.
+    You can also donate via the <a href="https://github.com/sponsors/Schneegans" target="_blank">GitHub Sponsors Program ↗</a>.
   </CustomCard>
   <CustomCard title="Via PayPal!" icon="simple-icons:paypal">
-    There's also a <a href="https://www.paypal.com/donate/?hosted_button_id=3F7UFL8KLVPXE" target="_blank">PayPal donation 🗗</a> link available.
+    There's also a <a href="https://www.paypal.com/donate/?hosted_button_id=3F7UFL8KLVPXE" target="_blank">PayPal donation ↗</a> link available.
   </CustomCard>
   <CustomCard title="Via Crypto!" icon="simple-icons:bitcoin">
-    Send a single cup of coffee or a monthly supply <a href="https://www.paypal.com/donate/?hosted_button_id=3F7UFL8KLVPXE" target="_blank">schneegans.cb.id 🗗</a>!
+    Send a single cup of coffee or a monthly supply <a href="https://www.paypal.com/donate/?hosted_button_id=3F7UFL8KLVPXE" target="_blank">schneegans.cb.id ↗</a>!
   </CustomCard>
 </CardGrid>
 


### PR DESCRIPTION
I'm using macOS Sequoia and encounter an invalid 🗗 character. Here I used a more commonly used character instead.

|Before|After|
|:-:|:-:|
|![](https://github.com/user-attachments/assets/907557df-6da2-4725-a27d-97e2869282da)|![](https://github.com/user-attachments/assets/e284c3f4-aae5-48fa-9683-23dc1f3b1342)|