### PR TITLE
Update window rules for hyprland on installation-on-linux.mdx

### DIFF
--- a/src/content/docs/installation-on-linux.mdx
+++ b/src/content/docs/installation-on-linux.mdx
@@ -176,13 +176,13 @@ Else, the menu will not float above other windows.
 
 ```
 // ~/.config/hypr/hyprland.conf
-windowrule = noblur, kando
-windowrule = opaque, kando
-windowrule = size 100% 100%, kando
-windowrule = noborder, kando
-windowrule = noanim, kando
-windowrule = float, kando
-windowrule = pin, kando
+windowrule = noblur, class:kando
+windowrule = opaque, class:kando
+windowrule = size 100% 100%, class:kando
+windowrule = noborder, class:kando
+windowrule = noanim, class:kando
+windowrule = float, class:kando
+windowrule = pin, class:kando
 ```
 
 Also, Kando cannot directly bind global shortcuts on Hyprland.


### PR DESCRIPTION
Source: 
- https://wiki.hyprland.org/Configuring/Window-Rules/
- https://github.com/hyprwm/hyprland-wiki/commit/68395f1cd4ba626d987716e272abdab462001830
Now windowrulev2 is windowrule and requieres class:app parameters. 