### PR TITLE
Add `.editorconfig` and `.gitattributes`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+# SPDX-License-Identifier: CC0-1.0
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+# SPDX-License-Identifier: CC0-1.0
+
+* text=auto eol=lf


### PR DESCRIPTION
I was trying to edit some documentation, but I then noticed some trailing spaces at the end of the line.

Here is a full report from the `editorconfig-checker`:


<details>
<summary>Click to expand</summary>

```
❯ editorconfig-checker
LICENSES/CC-BY-4.0.txt:
	3: Wrong amount of left-padding spaces(want multiple of 2)
	19: Wrong amount of left-padding spaces(want multiple of 2)
	21: Wrong amount of left-padding spaces(want multiple of 2)
	23: Wrong amount of left-padding spaces(want multiple of 2)
	25: Wrong amount of left-padding spaces(want multiple of 2)
	27: Wrong amount of left-padding spaces(want multiple of 2)
	29: Wrong amount of left-padding spaces(want multiple of 2)
	31: Wrong amount of left-padding spaces(want multiple of 2)
	33: Wrong amount of left-padding spaces(want multiple of 2)
	35: Wrong amount of left-padding spaces(want multiple of 2)
	37: Wrong amount of left-padding spaces(want multiple of 2)
	39: Wrong amount of left-padding spaces(want multiple of 2)
	43: Wrong amount of left-padding spaces(want multiple of 2)
	47: Wrong amount of left-padding spaces(want multiple of 2)
	49: Wrong amount of left-padding spaces(want multiple of 2)
	59: Wrong amount of left-padding spaces(want multiple of 2)
	61: Wrong amount of left-padding spaces(want multiple of 2)
	77: Wrong amount of left-padding spaces(want multiple of 2)
	81: Wrong amount of left-padding spaces(want multiple of 2)
	93: Wrong amount of left-padding spaces(want multiple of 2)
	95: Wrong amount of left-padding spaces(want multiple of 2)
	107: Wrong amount of left-padding spaces(want multiple of 2)
	109: Wrong amount of left-padding spaces(want multiple of 2)
	111: Wrong amount of left-padding spaces(want multiple of 2)
	116: Wrong amount of left-padding spaces(want multiple of 2)
	118: Wrong amount of left-padding spaces(want multiple of 2)
	120: Wrong amount of left-padding spaces(want multiple of 2)
	124: Wrong amount of left-padding spaces(want multiple of 2)
	126: Wrong amount of left-padding spaces(want multiple of 2)
	132: Wrong amount of left-padding spaces(want multiple of 2)
	134: Wrong amount of left-padding spaces(want multiple of 2)
	136: Wrong amount of left-padding spaces(want multiple of 2)
	140: Wrong amount of left-padding spaces(want multiple of 2)
	142: Wrong amount of left-padding spaces(want multiple of 2)
	146: Wrong amount of left-padding spaces(want multiple of 2)
	148: Wrong amount of left-padding spaces(want multiple of 2)
	150: Wrong amount of left-padding spaces(want multiple of 2)
	152: Wrong amount of left-padding spaces(want multiple of 2)
LICENSES/CC0-1.0.txt:
	46-47: Wrong amount of left-padding spaces(want multiple of 2)
	49-51: Wrong amount of left-padding spaces(want multiple of 2)
	54-58: Wrong amount of left-padding spaces(want multiple of 2)
REUSE.toml:
	Wrong line endings or no final newline
public/.well-known/org.flathub.VerifiedApps.txt:
	Wrong line endings or no final newline
public/CNAME:
	Wrong line endings or no final newline
src/assets/REUSE.toml:
	Wrong line endings or no final newline
src/content/docs/commandline-interface.mdx:
	Wrong line endings or no final newline
src/content/docs/compile-from-source.mdx:
	32: Trailing whitespace
	37: Trailing whitespace
	38-40: Wrong amount of left-padding spaces(want multiple of 2)
src/content/docs/contribution-guide.mdx:
	Wrong line endings or no final newline
src/content/docs/create-menu-themes.mdx:
	Wrong line endings or no final newline
	359: Wrong amount of left-padding spaces(want multiple of 2)
	376: Wrong amount of left-padding spaces(want multiple of 2)
	435: Wrong amount of left-padding spaces(want multiple of 2)
src/content/docs/create-sound-themes.mdx:
	Wrong line endings or no final newline
src/content/docs/icon-themes.mdx:
	24: Trailing whitespace
src/content/docs/index.mdx:
	Wrong line endings or no final newline
src/content/docs/installation-on-linux.mdx:
	60: Trailing whitespace
	61: Wrong amount of left-padding spaces(want multiple of 2)
	86: Wrong amount of left-padding spaces(want multiple of 2)
	91: Wrong amount of left-padding spaces(want multiple of 2)
	93: Wrong amount of left-padding spaces(want multiple of 2)
	102: Wrong amount of left-padding spaces(want multiple of 2)
	115: Wrong amount of left-padding spaces(want multiple of 2)
	118: Wrong amount of left-padding spaces(want multiple of 2)
	143: Wrong amount of left-padding spaces(want multiple of 2)
	146: Wrong amount of left-padding spaces(want multiple of 2)
	148: Wrong amount of left-padding spaces(want multiple of 2)
	149: Trailing whitespace
src/content/docs/installation-on-macos.mdx:
	Wrong line endings or no final newline
	34-36: Wrong amount of left-padding spaces(want multiple of 2)
src/content/docs/installation-on-windows.mdx:
	Wrong line endings or no final newline
src/content/docs/intro.mdx:
	Wrong line endings or no final newline
src/content/docs/item-open-uri.mdx:
	Wrong line endings or no final newline
src/content/docs/item-paste-text.mdx:
	Wrong line endings or no final newline
src/content/docs/item-run-command.mdx:
	Wrong line endings or no final newline
	67: Wrong amount of left-padding spaces(want multiple of 2)
src/content/docs/item-simulate-hotkey.mdx:
	Wrong line endings or no final newline
src/content/docs/item-simulate-macro.mdx:
	Wrong line endings or no final newline
src/content/docs/item-submenu.mdx:
	Wrong line endings or no final newline
	17: Trailing whitespace
src/content/docs/menu-themes.mdx:
	18: Trailing whitespace
	90: Trailing whitespace
src/content/docs/release-management.mdx:
	Wrong line endings or no final newline
	29-32: Wrong amount of left-padding spaces(want multiple of 2)
src/content/docs/sound-themes.mdx:
	Wrong line endings or no final newline
src/content/docs/translating.mdx:
	25: Trailing whitespace
	27: Wrong amount of left-padding spaces(want multiple of 2)
src/content/docs/usage.mdx:
	61: Trailing whitespace
	74: Trailing whitespace
	76: Trailing whitespace
src/styles/custom.css:
	Wrong line endings or no final newline
	137: Wrong amount of left-padding spaces(want multiple of 2)

93 errors found
```
</details>

I didn't reformat all files to break the git-blame. And we can ignore those errors from the LICENSES folder.