### PR TITLE
Docs: Fix typos in Hyprland-specific docs

### DIFF
--- a/src/content/docs/installation-on-linux.mdx
+++ b/src/content/docs/installation-on-linux.mdx
@@ -196,8 +196,8 @@ windowrule = pin, class:kando
 
 Also, Kando cannot directly bind global shortcuts on Hyprland.
 Instead, you specify a shortcut ID for each menu in Kando's menu editor and bind a key combination in `hyprland.conf`.
-To get the exact shortcut ID, you can use `hyperctl globalshortcuts` to list all currently registered global shortcuts.
-If you run the flatpak version of Kando and chose `example-menu` as the shortcut ID, you can would bind it like this:
+To get the exact shortcut ID, you can use `hyprctl globalshortcuts` to list all currently registered global shortcuts.
+If you run the flatpak version of Kando and chose `example-menu` as the shortcut ID, you would bind it like this:
 
 ```
 // ~/.config/hypr/hyprland.conf


### PR DESCRIPTION
* It's `hyprctl`, not `hyperctl`
* Also removed extra word