### PR TITLE
Fixed formatting for menu descriptions and conditions

### DIFF
--- a/src/content/docs/config-files.mdx
+++ b/src/content/docs/config-files.mdx
@@ -454,72 +454,49 @@ If the `menus` property is not present or empty at startup, Kando will create an
   [here](https://github.com/kando-menu/kando/tree/main/src/main/example-menus)!
 </Aside>
 
-The items in the `menus` list are called menu descriptions.
+The items in the `menus` list are called **menu descriptions**.
 They are JSON objects with the following properties:
 
-<div style="width:150px">Property</div> | Description -------- | ----------- `root`
-(_mandatory_) | The root menu item of the menu given as a Menu Item Description. [See
-below for details](#menu-item-descriptions). `shortcut: ""` | The shortcut which opens the
-menu. This is a string which can contain multiple keys separated by `+`. For example,
-`"Ctrl+Shift+K"` or `"Cmd+Shift+K"`. If empty, the menu will not have a shortcut. See
-[Valid Key Names](/valid-keynames) for details. `shortcutID: ""` | On some platforms,
-Kando can not bind shortcuts directly. In this case, you can use this property to assign
-an ID which can be used in the global shortcut configuration of your desktop environment.
-This should be lowercase and contain only ASCII characters and dashes. For example,
-`"main-trigger"`. `centered: false` | Whether the menu should be centered on the screen.
-If this is `false`, the menu will be opened at the position of the mouse cursor.
-`anchored: false` | Whether the submenus should be opened at the position where the menu
-was opened initially. If this is `false`, the submenus will be opened at the position of
-the mouse cursor. `hoverMode: false` | If enabled, menu items can be selected by hovering
-over them. `conditions: {}` | A dictionary of conditions which must be met for the menu to
-be shown. [See below for details](#menu-conditions). `tags: []` | A list of tags which can
-be used to filter the menu in the settings dialog. If a menu has no tags, it will only be
-shown in the all-menus list or if a collection has no tags at all.
+| Property             | Description                                                                                                                                                                                                                                                                          |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `root` (*mandatory*) | The root menu item of the menu, given as a **Menu Item Description**. [See below for details](#menu-item-descriptions).                                                                                                                                                              |
+| `shortcut`           | The shortcut that opens the menu. This is a string which can contain multiple keys separated by `+`, for example `"Ctrl+Shift+K"` or `"Cmd+Shift+K"`. If empty, the menu will not have a shortcut. See [Valid Key Names](/valid-keynames) for details.                               |
+| `shortcutID`         | On some platforms, Kando cannot bind shortcuts directly. In this case, you can assign an ID which can be used in the global shortcut configuration of your desktop environment. This should be lowercase and contain only ASCII characters and dashes, for example `"main-trigger"`. |
+| `centered`           | Whether the menu should be centered on the screen. If `false`, the menu will be opened at the position of the mouse cursor.                                                                                                                                                          |
+| `anchored`           | Whether submenus should be opened at the position where the menu was initially opened. If `false`, submenus will be opened at the position of the mouse cursor.                                                                                                                      |
+| `hoverMode`          | If enabled, menu items can be selected by hovering over them.                                                                                                                                                                                                                        |
+| `conditions`         | A dictionary of conditions which must be met for the menu to be shown. [See below for details](#menu-conditions).                                                                                                                                                                    |
+| `tags`               | A list of tags which can be used to filter the menu in the settings dialog. If a menu has no tags, it will only be shown in the all-menus list or if a collection has no tags at all.                                                                                                |
 
 ##### Menu Conditions
 
 The `conditions` property of a menu description can contain a dictionary of conditions.
 Only if all conditions are met, the menu will be shown.
 
-<div style="width:150px">Property</div> | Description -------- | ----------- `appName: ""`
-| The name of the application which must be focused for the menu to be shown. If it is a
-simple string, the condition is met if the name of the focused application contains the
-given string (case-insensitive). If the string starts with a `/`, it is interpreted as a
-regular expression. `windowName: ""` | The name of the window which must be focused for
-the menu to be shown. It is interpreted in the same way as `appName`. `screenArea: {}` | A
-dictionary with the optional properties `xMin`, `xMax`, `yMin`, and `yMax`. The menu will
-only be shown if the mouse cursor is within the given screen area. The values are given in
-pixels and are relative to the top-left corner of the screen. If a value is not given, the
-area is unbounded in this direction.
+The following properties can be used as **menu conditions**:
+
+| Property     | Description                                                                                                                                                                                                                                                                                                            |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `appName`    | The name of the application which must be focused for the menu to be shown. If it is a simple string, the condition is met if the name of the focused application contains the given string (case-insensitive). If the string starts with `/`, it is interpreted as a regular expression.                              |
+| `windowName` | The name of the window which must be focused for the menu to be shown. It is interpreted in the same way as `appName`.                                                                                                                                                                                                 |
+| `screenArea` | A dictionary with the optional properties `xMin`, `xMax`, `yMin`, and `yMax`. The menu will only be shown if the mouse cursor is within the given screen area. Values are given in pixels and are relative to the top-left corner of the screen. If a value is not specified, the area is unbounded in that direction. |
+
 
 ##### Menu Item Descriptions
 
 The layout of the menu is described by a tree of menu items.
 Each menu item is a JSON object with the following properties:
 
-<div style="width:150px">Property</div> | Description -------- | ----------- `name:
-"undefined"` | The name of the menu item. This is shown in the center of the menu when the
-item is hovered. The name of the root item defines the name of the menu. `iconTheme: ""` |
-This can either be one of the built-in icon themes (`"material-symbols-rounded"`,
-`"simple-icons"`, `"simple-icons-colored"`, `"base64"`, or `"emoji"`) or a subdirectory of
-the `icon-themes` subdirectory in Kando's config directory. [Click here for
-details](/icon-themes). `icon: ""` | The name of the icon from the given icon theme, an
-emoji like `"🚀"` (if the `iconTheme` is `"emoji"`), or a base64-encode image like
-`"data:image/gif;base64,..."` (if the icon theme is `"base64"`). [Click here for
-details](/icon-themes). `angle: number` (_optional_) | If given, this defines the angle of
-the menu item in degrees. If this is not given, the angle is calculated automatically. 0°
-means that the item is at the top of the menu, 90° means that the item is on the right
-side of the menu, and so on.
-<br />
-Among sibling items, the angle properties must be monotonically increasing, i.e. the first
-given angle must be smaller than the second, which must be smaller than the third, and so
-on. The first given angle must be greater or equal to 0° and all other angles must be
-smaller than the first given angle plus 360°. Any given angle which does not satisfy these
-conditions will be ignored. `type: "submenu"` | The type of the menu item. There are
-several types available. [See below for details](#menu-item-types). `data: {}` | Depending
-on the type of the item, this can or must contain additional data. [See below for
-details](#menu-item-types). `children: []` | If the menu item is a submenu, this contains
-a list of child items. Each object in this list is a menu item description as well.
+| Property             | Description                                                                                                                                                                                                                                                                                                                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`               | The name of the menu item. This is shown in the center of the menu when the item is hovered. The name of the root item defines the name of the menu.                                                                                                                                                                                                                            |
+| `iconTheme`          | Either one of the built-in icon themes (`material-symbols-rounded`, `simple-icons`, `simple-icons-colored`, `base64`, or `emoji`) or a subdirectory of the `icon-themes` directory in Kando’s config directory. [See details](/icon-themes).                                                                                                                                    |
+| `icon`               | The name of the icon from the selected icon theme, an emoji like `🚀` (when `iconTheme` is `emoji`), or a base64-encoded image such as `data:image/gif;base64,...` (when the icon theme is `base64`). [See details](/icon-themes).                                                                                                                                              |
+| `angle` (*optional*) | Defines the angle of the menu item in degrees. If omitted, the angle is calculated automatically. `0°` places the item at the top of the menu, `90°` on the right, and so on. Among sibling items, angles must be monotonically increasing. The first angle must be ≥ `0°`, and all following angles must be smaller than the first angle + `360°`. Invalid angles are ignored. |
+| `type`               | The type of the menu item. Several types are available. [See details](#menu-item-types).                                                                                                                                                                                                                                                                                        |
+| `data`               | Depending on the item type, this may contain additional data or be required. [See details](#menu-item-types).                                                                                                                                                                                                                                                                   |
+| `children`           | If the menu item is a submenu, this contains a list of child menu items. Each entry is itself a menu item description.                                                                                                                                                                                                                                                          |
+
 
 ##### Menu Item Types
 


### PR DESCRIPTION
Fixed formatting for menu descriptions and conditions in the documentation. Fixes #63 